### PR TITLE
fixed bug: remove import util.data.rand_split

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -3,7 +3,6 @@ from torchvision.datasets import CocoCaptions
 from torchvision import transforms as T
 from transformers import AutoFeatureExtractor
 
-from utils import rand_split
 import os
 
 try:


### PR DESCRIPTION
Fixed bug "`util.data.rand_split` are not found" in `data_loader.py` .

- Removed ` import util.data.rand_split`

